### PR TITLE
Add command line options and strict mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ outputs/
 tmp/
 src/
 node_modules/
+login.json

--- a/README.md
+++ b/README.md
@@ -21,8 +21,40 @@ NOTE: This is a different process than the original program. Its been redesigned
 $ git clone https://github.com/DrakeWitt/steam-yellow.git
 $ cd steam-yellow
 $ npm install
-$ node index.js username password
 ```
+
+## How to run (advanced):
+
+### Prompt
+```bash
+$ node index
+```
+
+Then enter information manually.
+
+### Command line arguments
+```bash
+$ node index --user username --pass password --flags 4
+```
+
+Flags default to everything enabled.
+
+### JSON file
+```bash
+$ node index ./login.json
+```
+
+Then in `./login.json`:
+
+```json
+{
+	"username": "username",
+	"password": "password",
+	"flags": 4
+}
+```
+
+Flags default to everything enabled.
 
 ### Use at your own risk. I'm not responsible for anything that happens. 
 

--- a/index.js
+++ b/index.js
@@ -1,3 +1,5 @@
+"use strict";
+
 /*
 * IMPORTS: Libraries that steam-yellow uses.
 */

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "index.js",
   "dependencies": {
     "inquirer": "^2.0.0",
+    "minimist": "^1.2.0",
     "steam": "^1.4.0",
     "steam-user": "^3.14.0"
   },


### PR DESCRIPTION
Also enables strict mode (#15). Couldn't be bothered creating a separate pull request for that.

Everything's documented in the README.md:

## How to run (advanced):

### Prompt
```bash
$ node index
```

Then enter information manually.

### Command line arguments
```bash
$ node index --user username --pass password --flags 4
```

Flags default to everything enabled.

### JSON file
```bash
$ node index ./login.json
```

Then in `./login.json`:

```json
{
	"username": "username",
	"password": "password",
	"flags": 4
}
```

Flags default to everything enabled.